### PR TITLE
Substitute ::int with :int per spec

### DIFF
--- a/cl-functions.lisp
+++ b/cl-functions.lisp
@@ -364,7 +364,7 @@
          (*global-environment* 3bgl-glsl::*glsl-base-environment*)
          ;; meta-types for defining the overloads
          (scalar (list :bool :int :uint :float :double))
-         (number (list ::int :uint :float :double))
+         (number (list :int :uint :float :double))
          (vec (list :vec2 :vec3 :vec4))
          (ivec (list :ivec2 :ivec3 :ivec4))
          (uvec (list :uvec2 :uvec3 :uvec4))


### PR DESCRIPTION
This allows code to be compiled with clasp. I strongly believe that ::int is a reader-error although it is accepted e.g. by sbcl. But even in sbcl ::int evaluates to :int.

With this change:
```lisp
(ql:quickload :3bgl-shader-example :verbose t)
(3bgl-shader-example:run-example)
````
-> Nice teapot