### PR TITLE
fix compilation warning

### DIFF
--- a/old-utils.lisp
+++ b/old-utils.lisp
@@ -2,6 +2,8 @@
 ;;; some brain-dead utils for shader-related stuff (recompiling
 ;;; shaders, setting uniforms by name, etc)
 
+;; print shaders as compiled for debugging
+(defparameter *print-shaders* nil)
 
 (defun uniform-index (program name)
   (if program

--- a/utils.lisp
+++ b/utils.lisp
@@ -2,9 +2,6 @@
 
 ;;; newer attempt at 'nicer' interface, + helper for updating shaders
 
-;; print shaders as compiled for debugging
-(defparameter *print-shaders* nil)
-
 (defparameter *default-recompilation-callback* nil)
 
 ;; this API's idea of what shader is currently active, so we know to


### PR DESCRIPTION
Hey! This PR fixes the following compilation warning (only visible when `quickload`ing the package with `:verbose t`):

```
; caught WARNING:
;   undefined variable: 3BGL-SHADERS::*PRINT-SHADERS*
```